### PR TITLE
[FIX] the rect param of the navy mouse

### DIFF
--- a/src/system/ONScripter.cpp
+++ b/src/system/ONScripter.cpp
@@ -294,7 +294,9 @@ int ONScripter::init()
 
 #ifdef __NAVY__
     // fake mouse
-    SDL_Rect rect = { .x = 0, .y = 0, .w = 8, .h = 8 };
+    const int mouse_w = 8;
+    const int mouse_h = 8;
+    SDL_Rect rect = { .x = 0, .y = 0, .w = mouse_w, .h = mouse_h };
     mouse_surface = AnimationInfo::allocSurface(rect.w, rect.h, texture_format);
     SDL_FillRect(mouse_surface, &rect, 0x00000000);
     rect = (SDL_Rect) { .x = 0, .y = 0, .w = 8, .h = 2 };
@@ -305,7 +307,7 @@ int ONScripter::init()
     SDL_FillRect(mouse_surface, &rect, 0x00ffffff);
     rect = (SDL_Rect) { .x = 6, .y = 0, .w = 2, .h = 8 };
     SDL_FillRect(mouse_surface, &rect, 0x00ffffff);
-    mouse_save_surface = AnimationInfo::allocSurface(rect.w, rect.h, texture_format);
+    mouse_save_surface = AnimationInfo::allocSurface(mouse_w, mouse_h, texture_format);
 #endif
 
     screenshot_surface = NULL;


### PR DESCRIPTION
The size of `mouse_save_surface` is not correctly set because the `rect` becomes `{.w=2, .h=8}` in the last assignment. I guess it shall be set to `{.w=8, .h=8}` instead. In the old version, failure appears after the call of `SDL_BlitSurface(screen_surface, &mouse_rect, mouse_save_surface, NULL);` in `ONScripter::flushDirect`.

P.S. Hope that my understanding is correct, considering the last commit of this part is 3 years ago, and I do not see any issue on github about that.